### PR TITLE
update dmvr link protocol

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         "seaborn",
         "tqdm",
         "pycocotools",
-        "dmvr @ git+git://github.com/deepmind/dmvr",
+        "dmvr @ git+https://github.com/deepmind/dmvr.git",
         "tf-models-nightly",
     ],
     cmdclass={


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

On January 11th Github stopped accepting the current protocol for dmvr in setup.py, breaking installation. I updated following https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported 