### PR TITLE
import image_classification from tensorflow legacy

### DIFF
--- a/scenic/dataset_lib/big_transfer/ops.py
+++ b/scenic/dataset_lib/big_transfer/ops.py
@@ -27,7 +27,7 @@ import tensorflow.compat.v1 as tf
 import tensorflow.compat.v2 as tf2
 import tensorflow_hub as hub
 
-from official.legacy.image_classification import augment
+from official.vision.beta.ops import augment
 from tensorflow_addons import image as image_utils
 
 AUTOAUGMENT_MODULE = "@experimental/andresp/cl238414945/nas_imagenet/1"

--- a/scenic/dataset_lib/big_transfer/ops.py
+++ b/scenic/dataset_lib/big_transfer/ops.py
@@ -27,7 +27,7 @@ import tensorflow.compat.v1 as tf
 import tensorflow.compat.v2 as tf2
 import tensorflow_hub as hub
 
-from official.vision.image_classification import augment
+from official.legacy.image_classification import augment
 from tensorflow_addons import image as image_utils
 
 AUTOAUGMENT_MODULE = "@experimental/andresp/cl238414945/nas_imagenet/1"

--- a/scenic/dataset_lib/video_ops.py
+++ b/scenic/dataset_lib/video_ops.py
@@ -30,7 +30,7 @@ from dmvr import builders
 from dmvr import processors as dmvr_processors
 import simclr.tf2.data_util as simclr_data
 import tensorflow as tf
-from official.legacy.image_classification import augment
+from official.vision.beta.ops import augment
 
 
 def crop_resize(frames: tf.Tensor,

--- a/scenic/dataset_lib/video_ops.py
+++ b/scenic/dataset_lib/video_ops.py
@@ -30,7 +30,7 @@ from dmvr import builders
 from dmvr import processors as dmvr_processors
 import simclr.tf2.data_util as simclr_data
 import tensorflow as tf
-from official.vision.image_classification import augment
+from official.legacy.image_classification import augment
 
 
 def crop_resize(frames: tf.Tensor,


### PR DESCRIPTION
Tensorflow moved this image_classification dependency to legacy breaking imports for the bit data pipeline

https://github.com/tensorflow/models/commit/29fa8c42326158424236efbe2a9f9f29c376ba86