### PR TITLE
Nit: Specify units

### DIFF
--- a/scenic/projects/baselines/clip/README.md
+++ b/scenic/projects/baselines/clip/README.md
@@ -51,8 +51,9 @@ with open('/path/to/clip.npy', 'wb') as f:
   np.save(f, params)
 ```
 
-Note that these models run natively on images with resolution 224 and normalized
-using `IMAGE_MEAN` and `IMAGE_STD`. The maximum text length is 77.
+Note that these models run natively on images with resolution 224px and
+normalized using `IMAGE_MEAN` and `IMAGE_STD`. The maximum text length is 77
+characters.
 
 ### Acknowledgment
 We would like to thank Ben Poole and Dirk Weissenborn for their contribution to


### PR DESCRIPTION
Wasn't sure whether 77 meant words or characters. From the source, it looks like it's chars.