### PR TITLE
Vid2Seq: Fixing typo in variable name: jave_jre->java_jre

### DIFF
--- a/scenic/projects/vid2seq/main.py
+++ b/scenic/projects/vid2seq/main.py
@@ -31,7 +31,7 @@ def get_model_cls(model_name: str) -> Callable[..., Any]:
 def main(rng: jnp.ndarray, config: ml_collections.ConfigDict, workdir: str,
          writer: metric_writers.MetricWriter):
   """Main function for the Vid2Seq project."""
-  jave_jre = JRE_BIN_JAVA
+  java_jre = JRE_BIN_JAVA
   os.environ['JRE_BIN_JAVA'] = java_jre
 
   # ensure arguments match


### PR DESCRIPTION
Script `main.py` contained a typo in the variable name, which caused `NameError: name 'java_jre' is not defined.`
Fixing the typo: jave_jre->java_jre