### PR TITLE
remove unnecessary double-dash in README tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ pip install .
 and run training for ViT on ImageNet:
 
 ```shell
-$ python scenic/main.py -- \
+$ python scenic/main.py \
   --config=scenic/projects/baselines/configs/imagenet/imagenet_vit_config.py \
   --workdir=./
 ```


### PR DESCRIPTION
the double-dash might be a leftover of a bazel / blaze run command, which is not required for python invocation.