### PR TITLE
Needs Python3.10 instead of 3.9 in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ upstreamed to Scenic's shared libraries.
 
 
 ### Quickstart
-You will need Python 3.9 or later. Download the code from GitHub
+You will need Python 3.10 or later. Download the code from GitHub
 
 ```shell
 $ git clone https://github.com/google-research/scenic.git


### PR DESCRIPTION
in python 3.9, there's a bug where GenericAlias causes errors. Fix: https://bugs.python.org/issue42233