### PR TITLE
Update `optax` requirement source in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ install_requires_core = [
     "immutabledict>=2.2.1",
     "clu>=0.0.6",
     "tensorflow-datasets",
-    "optax @ git+https://github.com/deepmind/optax.git@master",
+    "optax @ git+https://github.com/deepmind/optax.git@main",
 ]
 
 tests_require = [


### PR DESCRIPTION
The `optax` requirement in the `setup.py` was using the `master` branch to install the dependency. This was not working as `master` has been renamed to `main`. Fix this requirement.