### PR TITLE
Constrain optax to 0.1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ install_requires_core = [
     "immutabledict>=2.2.1",
     "clu>=0.0.6",
     "tensorflow-datasets",
-    "optax @ git+https://github.com/google-deepmind/optax.git@main",
+    "optax>=0.1.9,==0.1.*",
 ]
 
 tests_require = [


### PR DESCRIPTION
This assists downstream users of `scenic` (example: see https://github.com/google-research/perch/issues/613) by constraining `scenic`'s dependency on `optax` to

1. a specific minor version: as optax is still a 0.y.z project we might assume that the 0.1.z to 0.2.0 change contains breaking changes.
2. actual releases of optax, not a github  URL

Disclaimer: I don't know this history behind the extant dependency specification, e.bg. maybe there was a reason `scenic` needs to rely on bleeding-edge pre-release code.  Would the `scenic` authors be amenable to my change?